### PR TITLE
Support use of rounddown() in logging queries

### DIFF
--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -114,6 +115,40 @@ type DataFieldElements struct {
 type LabelFieldMetadata struct {
 	LabelName  string
 	LabelValue string
+}
+
+// Enumeration to represent the type of logging search query provided to the backend to perform
+type LogSearchQueryType int
+
+const (
+	QueryType_Undefined LogSearchQueryType = iota
+	QueryType_LogRecords
+	QueryType_LogMetrics_NoInterval
+	QueryType_LogMetrics_TimeSeries
+)
+
+func (s LogSearchQueryType) String() string {
+	switch s {
+	case QueryType_Undefined:
+		return "undefined"
+	case QueryType_LogRecords:
+		return "logRecords"
+	case QueryType_LogMetrics_NoInterval:
+		return "logMetrics-noInterval"
+	case QueryType_LogMetrics_TimeSeries:
+		return "logMetrics-timeSeries"
+	}
+	return "unknown"
+}
+
+// This structure is used to capture a summary of the log search results associated with
+// a given timestamp value. This structure is used to collect and collate the log search
+// results for a logging search query that uses the rounddown() function such that the query
+// returns log time series metrics. This structure helps ensure that the results of
+// the log search query are added to the data frame in a time ordered fashion.
+type LogTimeSeriesResult struct {
+	TimestampMs    int64
+	mMetricResults []*map[string]interface{}
 }
 
 // Query - Determine what kind of query we're making
@@ -409,16 +444,23 @@ func (o *OCIDatasource) outputFieldDefinitions(dataFieldDefns map[string]*DataFi
 }
 
 /*
- * Method determines whether the specified OCI Logging service query will return
- * numeric data (assuming it succeeds). This determination is made by checking
- * whether any of the Logging query functions, e.g. sum() or avg(), that cause
- * a query to return numeric data are used within the specified query string.
- * Method returns true if the query will return numeric data and false otherwise.
+ * Method determines which of the three following logging query types the specified
+ * OCI Logging service query is:
+ *   1. One that will return log records
+ *   2. One that will return metric data but does not specify a time interval
+ *     for the metrics
+ *   3. One that will return metric data and DOES specify a time interval.
+ * This determination is made by checking whether any of the Logging query statistical
+ * functions, e.g. sum() or avg(), that cause a query to return numeric data are used
+ * within the specified query string. If the query does reference one of the statistical
+ * functions and also includes the roundown() function then it is type #3, otherwise #2.
+ * If no statistical functions are referenced in the query then it is type #1.
+ * Method returns an enumerated value that identifies which query type is specified.
  *
  * @param loggingSearchQuery - Logging search query string
  */
-func (o *OCIDatasource) queryReturnsNumericData(loggingSearchQuery string) bool {
-	bNumericResult := false
+func (o *OCIDatasource) identifyQueryType(loggingSearchQuery string) LogSearchQueryType {
+	var queryType LogSearchQueryType = QueryType_Undefined
 
 	// Determine if the specified logging query utilizes any of the mathematical query functions, see
 	// https://docs.oracle.com/en-us/iaas/Content/Logging/Reference/query_language_specification.htm
@@ -428,13 +470,17 @@ func (o *OCIDatasource) queryReturnsNumericData(loggingSearchQuery string) bool 
 	reSum, _ := regexp.Compile(`sum\s*\(.+\)`)
 	reMin, _ := regexp.Compile(`min\s*\(.+\)`)
 	reMax, _ := regexp.Compile(`max\s*\(.+\)`)
+
+	// Regular expression to be used to determine if the query uses the rounddown() function
+	reInterval, _ := regexp.Compile(`rounddown\s*\(.+\)`)
+
 	/*
 	 * There are many valid ways to use the count aggregate operator within a logging
 	 * search query including:
 	 *   search "<compartment>[/<log group>[/<log>]]" | count
 	 *   search "<compartment>[/<log group>[/<log>]]" | summarize count()
-	 *   search "<compartment>[/<log group>[/<log>]]" | summarize count() by (<field1>)
-	 *   search "<compartment>[/<log group>[/<log>]]" | summarize count(<field1>) by (<field2>)
+	 *   search "<compartment>[/<log group>[/<log>]]" | summarize count() by <field1>
+	 *   search "<compartment>[/<log group>[/<log>]]" | summarize count(<field1>) by <field2>
 	 * The next regex object attempts to cover the first above case while the 2nd
 	 * regex object attempts to cover the remainder of the above cases
 	 */
@@ -449,12 +495,20 @@ func (o *OCIDatasource) queryReturnsNumericData(loggingSearchQuery string) bool 
 		reCountWithoutParens.Match([]byte(loggingSearchQuery)) == true ||
 		reMin.Match([]byte(loggingSearchQuery)) == true ||
 		reMax.Match([]byte(loggingSearchQuery)) == true {
-		bNumericResult = true
-	} else {
-		bNumericResult = false
-	}
 
-	return bNumericResult
+		// Finally check whether the query includes the rounddown() function since the
+		// inclusion of this function in the query will cause the OCI Logging service
+		// to return time series data in a single query response
+		if reInterval.Match([]byte(loggingSearchQuery)) == true {
+			queryType = QueryType_LogMetrics_TimeSeries
+		} else {
+			queryType = QueryType_LogMetrics_NoInterval
+		}
+
+	} else {
+		queryType = QueryType_LogRecords
+	}
+	return queryType
 
 }
 
@@ -617,7 +671,6 @@ func (o *OCIDatasource) processLogRecords(ctx context.Context, searchLogsReq Gra
 			request.Page = res.OpcNextPage
 			numpage++
 		} else {
-			o.logger.Debug("indexCountPag :", "indexCountPag", indexCountPag)
 			o.logger.Debug("Reducing data field values", "resultsCount", indexCountPag)
 			for _, dataFieldDefn := range mFieldDefns {
 				if dataFieldDefn.Type == ValueType_Time {
@@ -714,7 +767,25 @@ func (o *OCIDatasource) processLogMetrics(ctx context.Context, searchLogsReq Gra
 
 	numericFieldKey := ""
 	numericFieldType := ValueType_Undefined
-	metricFieldName := ""
+
+	// If the metric generated by the search query is aliased in the logging search
+	// query, e.g.
+	//     ... | summarize count() as foo
+	//     ... | summarize count(<field name>) as bar
+	//     ... | summarize sum(<field name>) as field_sum
+	// then we need to know what that alias is to know which corresponding field in the
+	// log search results is the numeric metric field. So check the query to see if it
+	// includes an alias for the query function result, if it does then save that alias
+	// otherwise the existing logic for determining the numeric field name will apply.
+	reFuncResultAlias, _ := regexp.Compile(`(count|sum|avg|min|max)\s*\([^\)]*\)\s+as\s+(?P<alias>[^\s]+)`)
+	if reFuncResultAlias.Match([]byte(searchQuery)) == true {
+		matches := reFuncResultAlias.FindStringSubmatch(searchQuery)
+		aliasIndex := reFuncResultAlias.SubexpIndex("alias")
+
+		numericFieldKey = matches[aliasIndex]
+		numericFieldType = ValueType_Float64
+		o.logger.Debug("Search query DID match query aggregation function alias regex", "alias", numericFieldKey)
+	}
 
 	// For the number of required data points loop through the logic to run the query for a sub-interval
 	// of the specified query time range. Process each search query's results and combine all of the results
@@ -784,9 +855,9 @@ func (o *OCIDatasource) processLogMetrics(ctx context.Context, searchLogsReq Gra
 
 				if _, ok := searchResultData[LogSearchResultsField_LogContent]; !ok {
 
-					// Prepare regular expression filters once for processing all results, using
+					// Prepare regular expression filter once for processing all results, using
 					// a raw string to simplify escaping
-					reFunc, _ := regexp.Compile(`^([a-zA-Z]+)\((.+)\)`)
+					reFunc, _ := regexp.Compile(`^(count|sum|avg|min|max)\s*\([^\)]*\)`)
 
 					var fieldDefn *DataFieldElements
 
@@ -817,13 +888,11 @@ func (o *OCIDatasource) processLogMetrics(ctx context.Context, searchLogsReq Gra
 
 									// Check whether the key contains one of the aggregation functions
 									if key == "count" {
-										metricFieldName = ""
 										numericFieldKey = key
 										// In the JSON content for the log record the count appears as an
 										// integer but when converted becomes a float value
 										numericFieldType = ValueType_Float64
-									} else if reFunc.Match([]byte(key)) == true {
-										metricFieldName = ""
+									} else if numericFieldKey == "" && reFunc.Match([]byte(key)) == true {
 										numericFieldKey = key
 										// The order of these checks is important since integer fields will likely
 										// be convertible as floating point values
@@ -836,7 +905,7 @@ func (o *OCIDatasource) processLogMetrics(ctx context.Context, searchLogsReq Gra
 												"panelId", queryPanelId, "refId", queryRefId, "value", value)
 											numericFieldType = ValueType_Undefined
 										}
-									} else {
+									} else if key != numericFieldKey {
 										// Save the information about the label field
 										labelFieldMetadata := LabelFieldMetadata{
 											LabelName:  key,
@@ -850,7 +919,7 @@ func (o *OCIDatasource) processLogMetrics(ctx context.Context, searchLogsReq Gra
 							// Process the label fields for the log metric to generate a unique key for the
 							// log metric. This logic is the same no matter the data type of the log metric
 							// field
-							metricFieldCombKey := metricFieldName
+							metricFieldCombKey := numericFieldKey
 							for _, labelFieldMetadata := range sLabelFields {
 								var labelValueStr string
 								// The label value when provided in the Field data structure is a string so just
@@ -870,8 +939,14 @@ func (o *OCIDatasource) processLogMetrics(ctx context.Context, searchLogsReq Gra
 							if numericFieldType == ValueType_Float64 {
 
 								// Get or create the data field elements structure for this field
+								//
+								// NOTE: Passing an empty string for the field name for now until
+								// the feature enhancement which allows the user to control the
+								// visualization legend is implemented and it is determined whether
+								// the field name is still applicable. Same comment applies to the
+								// next call to this function
 								fieldDefn = o.getCreateDataFieldElemsForField(mFieldDefns, int(numDataPoints),
-									metricFieldCombKey, metricFieldName, ValueType_Float64)
+									metricFieldCombKey, "", ValueType_Float64)
 
 								if floatValue, ok := searchResultData[numericFieldKey].(float64); ok {
 									fieldDefn.Values.([]*float64)[intervalCnt] = &floatValue
@@ -884,7 +959,7 @@ func (o *OCIDatasource) processLogMetrics(ctx context.Context, searchLogsReq Gra
 
 								// Get or create the data field elements structure for this field
 								fieldDefn = o.getCreateDataFieldElemsForField(mFieldDefns, int(numDataPoints),
-									metricFieldCombKey, metricFieldName, ValueType_Int)
+									metricFieldCombKey, "", ValueType_Int)
 
 								if intValue, ok := searchResultData[numericFieldKey].(int); ok {
 									fieldDefn.Values.([]*int)[intervalCnt] = &intValue
@@ -930,6 +1005,338 @@ func (o *OCIDatasource) processLogMetrics(ctx context.Context, searchLogsReq Gra
 }
 
 /*
+ * Data source class method that performs a logging search query and processes the
+ * returned log metric time series. This method ONLY processes results from a logging
+ * search query that returns a log metric time series, i.e. a query which uses the
+ * rounddown() function. The data returned by this method is held in the provided field
+ * definitions map.
+ *
+ * @param ctx - Additional context for the execution of the query
+ * @param searchLogsReq - Object containing the attributes of the search logs request from
+ *			the plugin frontend
+ * @param query - Object representing the characteristics of the query
+ * @param fromMs - The time (in milliseconds) that identifies the start of the query time range
+ * @param toMs - The time (in milliseconds) that identifies the end of the query time range
+ * @param mFieldDefns - A map of data field definitions where each element references an object
+ *			that defines the characteristics of a given field
+ */
+func (o *OCIDatasource) processLogMetricTimeSeries(ctx context.Context, searchLogsReq GrafanaSearchLogsRequest,
+	query backend.DataQuery, fromMs int64, toMs int64, mFieldDefns map[string]*DataFieldElements) error {
+
+	var queryRefId string = query.RefID
+	var queryPanelId string = searchLogsReq.PanelId
+	var timestampFieldKey string
+
+	// Implicit assumption that the request contains this field, must be set by the plugin frontend
+	searchQuery := searchLogsReq.SearchQuery
+
+	o.logger.Debug("Processing log metrics time series search query", "panelId", queryPanelId, "refId", queryRefId,
+		"query", searchQuery, "from", query.TimeRange.From.UTC(), "to", query.TimeRange.To.UTC())
+
+	// Populate a SearchLogsDetails structure to provide with the logging search API call
+	req1 := loggingsearch.SearchLogsDetails{}
+
+	// hardcoded for now
+	req1.IsReturnFieldInfo = common.Bool(false)
+
+	// Convert the current to/from time values into the format required for the Logging service search
+	// API call
+	start := time.Unix(fromMs/1000, (fromMs%1000)*1000000).UTC()
+	end := time.Unix(toMs/1000, (toMs%1000)*1000000).UTC()
+	start = start.Truncate(time.Millisecond)
+	end = end.Truncate(time.Millisecond)
+
+	// Set the current query time range start and end times for the current interval
+	req1.TimeStart = &common.SDKTime{start}
+	req1.TimeEnd = &common.SDKTime{end}
+	// Directly use the query provided by the user (where any template variable references
+	// have already been replaced by the plugin frontend)
+	req1.SearchQuery = common.String(searchQuery)
+
+	// Construct the Logging service SearchLogs request structure
+	request := loggingsearch.SearchLogsRequest{
+		SearchLogsDetails: req1,
+		Limit:             common.Int(LimitPerPage),
+	}
+	reg := common.StringToRegion(searchLogsReq.Region)
+	o.loggingSearchClient.SetRegion(string(reg))
+
+	// Perform the logs search operation
+	res, err := o.loggingSearchClient.SearchLogs(ctx, request)
+
+	if err != nil {
+		o.logger.Debug(fmt.Sprintf("Log search operation FAILED, panelId = %s, refId = %s, err = %s",
+			queryPanelId, queryRefId, err))
+		return errors.Wrap(err, "error fetching logs")
+	}
+	o.logger.Debug("Log search operation SUCCEEDED", "panelId", queryPanelId, "refId", queryRefId)
+
+	// Determine how many rows were returned in the search results
+	resultCount := *res.SearchResponse.Summary.ResultCount
+
+	if resultCount > 0 {
+
+		// Keep track of the labels to be applied to the field
+		sLabelFields := make([]*LabelFieldMetadata, 0)
+
+		numericFieldKey := ""
+		numericFieldType := ValueType_Undefined
+		var timestampMs int64
+
+		searchResultData, ok := (*res.SearchResponse.Results[0].Data).(map[string]interface{})
+		if ok == true {
+
+			if _, ok := searchResultData[LogSearchResultsField_LogContent]; !ok {
+
+				// Prepare regular expression filter once for processing all results, using
+				// a raw string to simplify escaping
+				reFunc, _ := regexp.Compile(`^(count|sum|avg|min|max)\s*\([^\)]*\)`)
+
+				// If the user has defined an alias for the timestamp as part of their query, e.g.
+				//   ... by rounddown(datetime, '<interval>') as interval
+				// then we need to know what that alias is to know which corresponding field in the
+				// log search results is the timestamp field. So check the query to see if it includes
+				// an alias for the timestamp, if it does then save that alias otherwise use the
+				// default timestamp name: 'datetime'
+				timestampFieldKey = ""
+				reTimestampAlias, _ := regexp.Compile(`rounddown\s*\([^\)]+\)\s+as\s+(?P<alias>[^,\s]+)`)
+				if reTimestampAlias.Match([]byte(searchQuery)) == true {
+					matches := reTimestampAlias.FindStringSubmatch(searchQuery)
+					aliasIndex := reTimestampAlias.SubexpIndex("alias")
+					timestampFieldKey = matches[aliasIndex]
+					o.logger.Debug("Search query DID match timestamp alias regex", "alias", timestampFieldKey)
+				} else {
+					timestampFieldKey = "datetime"
+				}
+
+				// If the metric generated by the search query is aliased in the logging search
+				// query, e.g.
+				//     ... | summarize count() as foo
+				//     ... | summarize count(<field name>) as bar
+				//     ... | summarize sum(<field name>) as field_sum
+				// then we need to know what that alias is to know which corresponding field in the
+				// log search results is the numeric metric field. So check the query to see if it
+				// includes an alias for the query function result, if it does then save that alias
+				// otherwise the existing logic for determining the numeric field name will apply
+				reFuncResultAlias, _ := regexp.Compile(`(count|sum|avg|min|max)\s*\([^\)]*\)\s+as\s+(?P<alias>[^\s]+)`)
+				if reFuncResultAlias.Match([]byte(searchQuery)) == true {
+					matches := reFuncResultAlias.FindStringSubmatch(searchQuery)
+					aliasIndex := reFuncResultAlias.SubexpIndex("alias")
+
+					numericFieldKey = matches[aliasIndex]
+					numericFieldType = ValueType_Float64
+
+					o.logger.Debug("Search query DID match query aggregation function alias regex", "alias", numericFieldKey)
+				}
+
+				mLogTimeSeriesResults := make(map[int64]*LogTimeSeriesResult)
+				// Keep track of the unique timestamps encountered so the results timestamp
+				// group map can be walked in sorted order later
+				sTimestampKeys := make([]int64, 0)
+
+				// Note that unless the user specifically sorts the results of the logging search
+				// query on the date/timestamp field, e.g.
+				//     ... | <aggregation operation> by rounddown(datetime, '5m') as interval | sort by interval
+				// there is NO guarantee that the results returned by the OCI Logging service are
+				// time ordered. While Grafana handles the out of order data situation sometimes
+				// it doesn't do so consistently and when it doesn't work the resulting visualization is
+				// unusable.
+				//
+				// One option would be to add a sort clause to the user's search query but this could be
+				// fairly complicated given the extreme variability of logging search queries that a user
+				// could provide (when you consider they might already have a sort clause in the query). In
+				// addition the notion of modifying user input without their approval or understanding is
+				// sub-optimal. So to work around this issue, the following logic walks the logging search
+				// results one result at a time extracting the timestamp field for each result and building
+				// a results timestamp group map where each entry contains a map of corresponding metric values
+				// for that timestamp. The keys of the results timestamp group map are then sorted so the
+				// metric data is placed in the data frame to be provided to Grafana in time sorted order.
+
+				for rowCount, logSearchResult := range res.SearchResponse.Results {
+					searchResultData, ok := (*logSearchResult.Data).(map[string]interface{})
+					if ok == true {
+						if timestampFloat, ok := searchResultData[timestampFieldKey].(float64); ok {
+							timestampMs = int64(timestampFloat)
+
+							// Check if a results timestamp group map entry does not exist for the current
+							// timestamp in which case create a new map entry and save a pointer to the
+							// log search results. Otherwise add the search result fields to the existing
+							// timestamp group map entry
+							if _, ok = mLogTimeSeriesResults[timestampMs]; !ok {
+								o.logger.Debug(fmt.Sprintf("Results timestamp grouping does NOT exist: %d", timestampMs))
+								var tempTimestampResults LogTimeSeriesResult
+								tempTimestampResults.TimestampMs = timestampMs
+								tempTimestampResults.mMetricResults = make([]*map[string]interface{}, 0)
+								mLogTimeSeriesResults[timestampMs] = &tempTimestampResults
+
+								sTimestampKeys = append(sTimestampKeys, timestampMs)
+							}
+							mLogTimeSeriesResults[timestampMs].mMetricResults =
+								append(mLogTimeSeriesResults[timestampMs].mMetricResults, &searchResultData)
+
+						} else {
+							o.logger.Debug("Unable to extract timestamp value from log row",
+								"panelId", queryPanelId, "refId", queryRefId, "timestampFieldKey", timestampFieldKey,
+								"rowCount", rowCount)
+						}
+					} else {
+						o.logger.Error("Unable to map result data elements",
+							"panelId", queryPanelId, "refId", queryRefId, "row", rowCount)
+					}
+				}
+				// Now sort the list of timestamps so the map of results timestamp groups can be walked in
+				// sorted time order
+				sort.Slice(sTimestampKeys, func(i, j int) bool { return sTimestampKeys[i] < sTimestampKeys[j] })
+
+				var fieldDefn *DataFieldElements
+				var timestampResults *LogTimeSeriesResult
+				var searchResultFields map[string]interface{}
+
+				tgtNumRows := len(mLogTimeSeriesResults)
+
+				// Now that we have the results sorted by time, populate the data field definition
+				// structures to be used to construct the data frame that will be passed to the
+				// plugin frontend (and ultimately Grafana)
+				for rowCount, timestampMs := range sTimestampKeys {
+					timestampResults = mLogTimeSeriesResults[timestampMs]
+
+					if rowCount == 0 {
+						// Loop through the keys for the first log results entry for the associated
+						// timestamp to determine what kind of fields we have in the results
+						for key, value := range *timestampResults.mMetricResults[0] {
+							// Check whether the key contains one of the aggregation functions
+							if key == "count" {
+								numericFieldKey = key
+								// In the JSON content for the log record the count appears as an
+								// integer but when converted becomes a float value
+								numericFieldType = ValueType_Float64
+
+								// If the numeric field key was not already identified from the search
+								// query and the current key contains one of the known query mathematical
+								// functions then this is the numeric field in the log search results
+							} else if numericFieldKey == "" && reFunc.Match([]byte(key)) == true {
+								numericFieldKey = key
+								// The order of these checks is important since integer fields will likely
+								// be convertible as floating point values
+								if _, ok := value.(int); ok {
+									numericFieldType = ValueType_Int
+								} else if _, ok := value.(float64); ok {
+									numericFieldType = ValueType_Float64
+								} else {
+									o.logger.Error("Unable to determine numeric data type for field value",
+										"panelId", queryPanelId, "refId", queryRefId, "value", value)
+									numericFieldType = ValueType_Undefined
+								}
+
+								// If the current key is not for the timestamp or metric field then treat
+								// it is a label field
+							} else if key != timestampFieldKey && key != numericFieldKey {
+								// Save the information about the label field
+								labelFieldMetadata := LabelFieldMetadata{
+									LabelName:  key,
+									LabelValue: "",
+								}
+								sLabelFields = append(sLabelFields, &labelFieldMetadata)
+							}
+						}
+					} // end if first row
+
+					// There should always be a timestamp field so go ahead and process that
+					// field first
+					fieldDefn = o.getCreateDataFieldElemsForField(mFieldDefns, tgtNumRows,
+						timestampFieldKey, timestampFieldKey, ValueType_Time)
+
+					// Convert the timestamp field value for the current results timestamp group into
+					// a time.Time object and add that value to the timestamp field values
+					timestamp := time.Unix(timestampMs/1000, (timestampMs%1000)*1000000).UTC()
+					fieldDefn.Values.([]*time.Time)[rowCount] = &timestamp
+
+					for _, searchResultFieldsPtr := range timestampResults.mMetricResults {
+						searchResultFields = *searchResultFieldsPtr
+
+						// Process the label fields for the log metric to generate a unique key for the
+						// log metric. This logic is the same no matter the data type of the log metric
+						// field
+						metricFieldCombKey := numericFieldKey
+						for _, labelFieldMetadata := range sLabelFields {
+							var labelValueStr string
+							// The label value when provided in the Field data structure is a string so just
+							// output a string representation of the label field's value without worrying about
+							// the actual type. However sometimes the label field may be null so handle that case
+							// cleanly
+							if searchResultFields[labelFieldMetadata.LabelName] != nil {
+								labelValueStr = fmt.Sprintf("%v", searchResultFields[labelFieldMetadata.LabelName])
+							} else {
+								labelValueStr = "null"
+							}
+							labelFieldMetadata.LabelValue = labelValueStr
+							metricFieldCombKey += "_" + labelValueStr
+						}
+
+						// Process the numeric field in the log search results
+						if numericFieldType == ValueType_Float64 {
+
+							// Get or create the data field elements structure for this field
+							//
+							// NOTE: Passing an empty string for the field name for now until
+							// the feature enhancement which allows the user to control the
+							// visualization legend is implemented and it is determined whether
+							// the field name is still applicable. Same comment applies to the
+							// next call to this function
+							fieldDefn = o.getCreateDataFieldElemsForField(mFieldDefns, tgtNumRows,
+								metricFieldCombKey, "", ValueType_Float64)
+
+							if floatValue, ok := searchResultFields[numericFieldKey].(float64); ok {
+								fieldDefn.Values.([]*float64)[rowCount] = &floatValue
+							} else {
+								o.logger.Error("Unable to extract float field value",
+									"panelId", queryPanelId, "refId", queryRefId, "field", numericFieldKey)
+							}
+
+						} else if numericFieldType == ValueType_Int {
+
+							// Get or create the data field elements structure for this field
+							fieldDefn = o.getCreateDataFieldElemsForField(mFieldDefns, tgtNumRows,
+								metricFieldCombKey, "", ValueType_Int)
+
+							if intValue, ok := searchResultFields[numericFieldKey].(int); ok {
+								fieldDefn.Values.([]*int)[rowCount] = &intValue
+							} else {
+								o.logger.Error("Unable to extract int value for ",
+									"panelId", queryPanelId, "refId", queryRefId, "field", numericFieldKey)
+							}
+
+						} else {
+							o.logger.Debug("Encountered unexpected field value type for numeric results logging query",
+								"panelId", queryPanelId, "refId", queryRefId)
+						}
+						// Populate the label values for this log metric
+						for _, labelFieldMetadata := range sLabelFields {
+							fieldDefn.Labels[labelFieldMetadata.LabelName] = labelFieldMetadata.LabelValue
+							// Clear the label value field so the value for the label field doesn't get re-used
+							// for the next result
+							labelFieldMetadata.LabelValue = ""
+						}
+					}
+					rowCount++
+				}
+			} else {
+				o.logger.Debug("Log search results should NOT contain log records",
+					"panelId", queryPanelId, "refId", queryRefId)
+			}
+		} else {
+			o.logger.Debug("Unable to assert search result data is a string map",
+				"panelId", queryPanelId, "refId", queryRefId)
+		}
+	} else { // result count is <= 0
+		o.logger.Debug("No results returned by query", "panelId", queryPanelId,
+			"refId", queryRefId, "resultCount", *res.SearchResponse.Summary.ResultCount)
+	}
+
+	return nil
+}
+
+/*
  * Data source class method that processes a set of query requests received from the
  * plugin frontend and provides back a query response for each of the queries
  * referenced in the request. The data returned by this method is formatted as data
@@ -965,19 +1372,24 @@ func (o *OCIDatasource) searchLogsResponse(ctx context.Context, req *backend.Que
 
 		// Determine whether the specified query will return numeric data (based on its use of numerical
 		// logging query functions)
-		bNumericResult := o.queryReturnsNumericData(ts.SearchQuery)
+		logQueryType := o.identifyQueryType(ts.SearchQuery)
 
 		var processErr error
 		// Call the appropriate function to process the logging search results based on the expected
-		// type of results (metrics or log records). The data extracted from the log search results
-		// is held in the data field definitions map which is used below to construct the data frame
-		// containing the data returned by the query in a format that Grafana can understand.
-		if bNumericResult == true {
-			o.logger.Debug("Logging query WILL return numeric data", "refId", query.RefID)
+		// type of results (metric time series, metrics with no interval, or log records). The data
+		// extracted from the log search results is held in the data field definitions map which is
+		// used below to construct the data frame containing the data returned by the query in a format
+		// that Grafana can understand.
+		if logQueryType == QueryType_LogMetrics_TimeSeries {
+			o.logger.Debug("Logging query WILL return numeric data over intervals", "refId", query.RefID)
+			// Call method that parses log metric results and produces the required field definitions
+			processErr = o.processLogMetricTimeSeries(ctx, ts, query, fromMs, toMs, mFieldData)
+		} else if logQueryType == QueryType_LogMetrics_NoInterval {
+			o.logger.Debug("Logging query will NOT return numeric data over entire time range", "refId", query.RefID)
 			// Call method that parses log metric results and produces the required field definitions
 			processErr = o.processLogMetrics(ctx, ts, query, fromMs, toMs, mFieldData)
-		} else {
-			o.logger.Debug("Logging query will NOT return numeric data", "refId", query.RefID)
+		} else { // QueryType_LogRecords
+			o.logger.Debug("Logging query will return log records for the specified time interval", "refId", query.RefID)
 			// Call method that parses log record results and produces the required field definitions
 			processErr = o.processLogRecords(ctx, ts, query, fromMs, toMs, mFieldData)
 		}
@@ -989,7 +1401,6 @@ func (o *OCIDatasource) searchLogsResponse(ctx context.Context, req *backend.Que
 		 * Create the data frame for the current logging search query using the accumulated
 		 * field definitions derived from the query results
 		 */
-
 		var frame *data.Frame = nil
 		// Create an array of data.Field pointers, one for each data field definition in the
 		// field definition map


### PR DESCRIPTION
### Overview

The purpose of this change is allow logging search queries within Grafana data panels using the OCI Logs datasource plugin to use the [rounddown() function of the OCI Logging search query language](https://docs.oracle.com/en-us/iaas/Content/Logging/Reference/query_language_specification.htm#query_language_specification__scalar_operators) to have the logging search query to return time series metric data. The rounddown() function allows the user to indirectly specify a time interval over which the resulting metrics are computed and returned, for example: 5m, 10m, 1h, 1w.

A secondary aspect of this change is to add support for the use of aliases within a logging search query in a Grafana data panel. Aliases can be used in logging search queries to provide another name (or alias) for the result of a mathematical aggregation function, a grouped by field, or a time interval specified through the `rounddown()` function. For example:

`search "<Compartment OCID>" | where <filtering criteria> | summarize count() as <alias1> by data.log_length as <alias2>, rounddown(datetime, '$interval') as <alias3>`

Support for aliases has been added to the plugin since if an alias is used for the aggregation function result or timestamp, the plugin logic needs to know the alias(es) to properly interpret the results returned by a logging search query.

### Current Behavior

The plugin based on the current code base does not properly handle the inclusion of the `rounddown()` function or the use of aliases for the aggregation function or time interval. The type of issues that occur, as exemplified by the following screen shots of various test dashboards with logging search queries using these two logging query language capabilities, include:
- Metric data is not properly displayed (due to time interval usage)
- Aliased time interval field treated as a label value rather than timestamp value
- 'Data is massing a number field' error shown on data panel when using an aliased mathematical aggregation function
 
![rounddown-notWorking-NumericQueriesDashboard1](https://user-images.githubusercontent.com/37004987/182725085-77e37951-c6f8-4c60-ac56-ccff0c80f679.png)
![rounddown-notWorking-NumericQueriesDashboard2](https://user-images.githubusercontent.com/37004987/182725100-70ad2caa-f1c1-4328-852f-01d349e56d49.png)
![rounddown-notWorking-CountAggregationNoFieldQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182725113-8793faea-1b10-4d1f-a17b-7938bd9ad9fb.png)
![rounddown-notWorking-CountAggregationWithFieldQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182725124-c5b4fb61-b6e7-4a85-a2d5-925e6c828905.png)
![rounddown-notWorking-SumAggregationQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182725136-941121a8-f0ac-4a95-a69c-cc77318721ad.png)
![rounddown-notWorking-AvgAggregationQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182725145-bccddfe1-f4c6-4b5b-bb35-a905a38b85a2.png)
![rounddown-notWorking-MinAggregationQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182725155-c0b11b2d-3f69-4011-9c78-ec48157d7c52.png)
![rounddown-notWorking-MaxAggregationQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182725162-6134ed6f-7378-4948-b18b-34682cc6f3e2.png)
![rounddown-notWorking-GroupByMultipleFieldQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182725174-2b1c71bf-b4f2-4ae0-9961-3dd65ec1c6f4.png)
![rounddown-notWorking-GroupByMultipleFieldQueryTestsDashboard2](https://user-images.githubusercontent.com/37004987/182725192-de6b150a-438e-4e28-8244-514107cf5bec.png)

### Description of Changes

A summary of the plugin code changes to support the specification of a time interval and/or field aliases in logging search queries within Grafana data panels include:
- Update to the function that processes logging search queries that return metrics but do not specify a time interval to handle the specification of an alias for the mathematical aggregation function result.
- Addition of a new function for processing the results returned by a logging search query that specifies a time interval via the `rounddown()` function which:
** Determines if the search query includes a time interval alias and uses the alias as the timestamp field name if it does.
** Determines if the search query includes a mathematical aggregation function result alias and uses the alias as the metric field name if it does.
** Walks the returned results and groups them by the associated timestamp for each result.
** Sorts the timestamp grouped results by timestamp value.
** Walks the sorted timestamp grouped results and for each timestamp, processes the associated results and populates the field definitions and values
** Returns the resulting field definitions and values so they can be used to populate a data frame

### Updated Behavior
With these changes in place the example test dashboard panels shown previously now show appropriate data as demonstrated by the following screen shots:
![rounddown-working-NumericQueriesDashboard1](https://user-images.githubusercontent.com/37004987/182730600-1e528ef0-2113-4713-bd9a-edfd24deadbb.png)
![rounddown-working-NumericQueriesDashboard2](https://user-images.githubusercontent.com/37004987/182730604-cfd58f17-6da6-44c6-97bc-042ead09de3a.png)
![rounddown-working-NumericQueriesDashboard3](https://user-images.githubusercontent.com/37004987/182730626-2beb1ce4-758f-4d64-b22d-660ef1f6fc66.png)
![rounddown-working-CountAggregationNoFieldQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182730885-1dcca163-447c-4ccd-91fc-725f0b0a3b6f.png)
![rounddown-working-CountAggregationWithFieldQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182730889-2d4cbe2a-0146-43fe-80f2-dbe021a338df.png)
![rounddown-working-SumAggregationQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182730903-ddcb264c-9627-47eb-ab69-90615d106c9d.png)
![rounddown-working-AvgAggregationQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182730914-403ca418-eb80-4797-995b-fe6ac766b80b.png)
![rounddown-working-MinAggregationQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182730921-76900d83-18ff-4314-ab4d-8015768c5818.png)
![rounddown-working-MaxAggregationQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182730927-b09ba335-0eb7-4428-8db6-3c02633cbd48.png)
![rounddown-working-GroupByMultipleFieldQueryTestsDashboard1](https://user-images.githubusercontent.com/37004987/182730959-bc43d81d-b8d8-4acb-bbf4-e87373288146.png)
![rounddown-working-GroupByMultipleFieldQueryTestsDashboard2](https://user-images.githubusercontent.com/37004987/182730966-1d7d99db-233a-4b55-80b6-d125f9b2c186.png)


### Testing
These changes were tested on the following platforms and browser combinations:

- MacOS & Chrome

The changes were tested to support both of the scenarios listed in the overview section above as well as existing use cases including:

- Existing numeric logging query data panels with the addition of corresponding data panels that provide a time interval for the query
- Various combinations of unaliased and aliased aggregate function, grouped by fields, and time interval in search queries using the following aggregation functions:
* count() with no field
* count() with field
* sum() aggregation
* avg() aggregation
* min() aggregation
* max() aggregation
- Various combinations of queries with multiple grouped by fields with various combinations of:
* Multiple string fields
* Multiple numeric fields
* Mixture of string and numeric fields in various orders, up to three group by fields plus interval
