### PR TITLE
 Adding policy statement to allow search logs 

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -89,6 +89,7 @@ Under the **Policy** tab click **Create Policy** and create policies allowing th
 - `allow group grafana to read log-groups in tenancy`
 - `allow group grafana to read log-content in tenancy`
 - `allow group grafana to read compartments in tenancy`
+- `allow group grafana to read audit-events in tenancy`
 
 ![OCIConsole-GroupLogsPolicyCreate-Screenshot](images/OCIConsole-GroupLogsPolicyCreate-Screenshot.png)
 


### PR DESCRIPTION
According to documentation 

search "compartment/_Audit" requires just AUDIT_EVENT_READ.  

Adding the last  statement 
allow group grafana to read audit-events in tenancy will provide AUDIT_EVENT_READ

https://docs.oracle.com/en-us/iaas/Content/Logging/Concepts/searchinglogs.htm

Signed-off-by: José Eduardo Delgado Canchola - jedcanchola@gmail.com
