### PR TITLE
Fix for oci-grafana-logs/issues/117 and bump cross-spawn from 7.0.3 to 7.0.6

### DIFF
--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -41,10 +41,10 @@ export class ConfigEditor extends PureComponent<Props, State> {
         },
       });
     }
-  }  
+  }
   render() {
     const { options } = this.props;
-    options.jsonData.profile0 = 'DEFAULT';
+
     return (
       <FieldSet label="Connection Details">
         <InlineField
@@ -76,9 +76,9 @@ export class ConfigEditor extends PureComponent<Props, State> {
         />
       </InlineField>
             </>
-        )}        
+        )}
 
-        {options.jsonData.environment === AuthProviders.OCI_USER  && (
+      {options.jsonData.environment === AuthProviders.OCI_USER  && (
               <>
         <InlineField              
               label="Tenancy Mode"
@@ -96,7 +96,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
               />
             </InlineField>
             </>
-        )}
+        )}   
             <br></br>
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3850,9 +3850,9 @@ create-require@^1.1.0:
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
@@ -9205,10 +9205,10 @@ update-browserslist-db@^1.1.0:
     escalade "^3.1.2"
     picocolors "^1.0.1"
 
-uplot@1.6.31:
-  version "1.6.31"
-  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.31.tgz#092a4b586590e9794b679e1df885a15584b03698"
-  integrity sha512-sQZqSwVCbJGnFB4IQjQYopzj5CoTZJ4Br1fG/xdONimqgHmsacvCjNesdGDypNKFbrhLGIeshYhy89FxPF+H+w==
+uplot@1.6.30:
+  version "1.6.30"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.30.tgz#1622a96b7cb2e50622c74330823c321847cbc147"
+  integrity sha512-48oVVRALM/128ttW19F2a2xobc2WfGdJ0VJFX00099CfqbCTuML7L2OrTKxNzeFP34eo1+yJbqFSoFAp2u28/Q==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
The pull request contains 

- fix for the GitHub issue oci-grafana-logs/issues/117
- Bump cross-spawn from 7.0.3 to 7.0.6